### PR TITLE
WIP - open term types

### DIFF
--- a/PurePy-spec.tex
+++ b/PurePy-spec.tex
@@ -527,6 +527,11 @@ closure variables at the current scoping level. The returned type is the type of
 the name currently being defined. The function $\mathrm{close}$ removes the second argument from all bindings in the
 updated environment.
 
+The rules for conditional evaluation ($\ruleName{if1}$ and $\ruleName{if2}$) follow a similar structure to the ones for
+function evaluation. If the conditional statement is on the global scope (i.e., $\carrow{0}$), then all sub-expressions
+and sub-statements must be closed. If it is inside a nested scope, each sub-term is typed in sequence, and the
+returned type is again the union of the open term types of the sub-terms.  
+
 The rule for function definition $\ruleName{def}$ works similarly to the one for lambda expressions, with the added step of
 closing the environment by the function name $f$ in the returned environment stack.
 

--- a/PurePy-spec.tex
+++ b/PurePy-spec.tex
@@ -504,9 +504,9 @@ variables $\Sigma$ at any nesting depth (e.g., a free variable might be closed b
 enclosing scope).
 
 We will start by illustrating the typing rules for expressions. A constant has an empty type, and does not change
-the stack. For variables, there are three different cases. In $\ruleName{var1}$, a variable is evaluated which is
-already bound by the current scope $\Gamma$. Therefore, its type can be read from the environment, and the
-variable itself is added to the set of closure variables at the current scope (to circumvent the issue explained in
+the stack. For variables, there are three different cases. In $\ruleName{var1}$, the variable is
+already bound in the current scope $\Gamma$. Therefore, its type can be read from the environment, and the
+variable itself is added to the set of closure variables at the current scope level (to circumvent the issue explained in
 Section~\ref{sec:captured-vars}). If the variable is not bound in the current environment, it is typed at the
 surrounding scope as shown in $\ruleName{var2}$. The base-case is illustrated by $\ruleName{var3}$, where a variable
 is typed at the global scope (i.e. $\carrow{0}$). If the variable is not defined at the global scope either, it receives
@@ -525,7 +525,7 @@ the returned stack the one of the last typing judgement.
 For statements, the $\ruleName{pass}$ is trivial. For an assignment, the assigned variable cannot be part of the set of
 closure variables at the current scoping level. The returned type is the type of the right-hand side expression without
 the name currently being defined. The function $\mathrm{close}$ removes the second argument from all bindings in the
-updated environment.
+updated environment (i.e., $\mathrm{close}(\Gamma, x)(y) = \Gamma(y) \setminus \{x\}$).
 
 The rules for conditional evaluation ($\ruleName{if1}$ and $\ruleName{if2}$) follow a similar structure to the ones for
 function evaluation. If the conditional statement is on the global scope (i.e., $\carrow{0}$), then all sub-expressions

--- a/PurePy-spec.tex
+++ b/PurePy-spec.tex
@@ -453,6 +453,88 @@ by \pyinline{return None}. This ensures every function returns, even if it is no
 
 \subsubsection{Late binding and mutual recursion}
 
+Python uses a form of \emph{late binding}, where most variables only need to be defined at execution time. For example, 
+the following program is valid: 
+
+\begin{python}
+def foo():
+    return x
+
+x = 10
+y = foo()
+\end{python}
+
+While \pyinline{x} is not defined before its usage inside the definition of \pyinline{foo}, it is defined by the
+time the function is called. Therefore, Python uses a limited form of \emph{dynamic scoping}. In PurePy, we would
+like to restrict this form of scoping to something that is easier to statically analyse, and less error-prone 
+(see Section~\ref{sec:captured-vars}). However, some forms of late binding must be allowed, as we could otherwise not
+define (mutually) recursive functions:
+
+\begin{python}
+def even(n):
+    if n == 0: return True
+    else: odd (n-1)
+
+def odd(n):
+    if n == 0: return False
+    else: return even (n-1)
+\end{python}
+
+The function \pyinline{even} refers to \pyinline{odd} before that function is defined. We restrict the
+allowed forms of late binding by the introduction of a type system, which uses \emph{open term types},
+i.e., a term is allowed to be dependent on yet undefined variables.
+
+Figure~\ref{fig:open-term-types} introduces several auxiliary symbols we need for the typing rules. Each
+open term (i.e, statement or expression) has an \emph{open term type} $\tau$, which denotes the set of
+variable names that are unbound in the respective term.
+
+As with other programming languages, scoping in Python and PurePy has nesting, i.e., each \pyinline{def}
+and \pyinline{lambda} opens a new scope. Therefore, the typing rules are expressed in terms of 
+\emph{frames} $\Psi$, which correspond to the different nesting levels. A particular frame $\Psi$ consists
+of the set of \emph{closure variables} $\Sigma$, i.e., the set of variables defined in the current frame
+that are used within a closure (see Section~\ref{sec:captured-vars}), and an \emph{environment} $\Gamma$,
+which maps variable names to open term types. Finally, a \emph{frame stack} $\Delta$ holds the nested
+scoping frames.
+
+Figures~\ref{fig:open-stmts-type-rules} and \ref{fig:open-expr-type-rules} illustrate the typing relation for statements
+and expressions respectively. Both have the same shape, where a statement or an expression evaluates under a
+stack $\Delta$ to an open type $\tau$ and an updated stack $\Delta'$. Statements can change the stack by introducing
+new bindings in $\Gamma$ through assignments at the top-most frame, while expressions can change the set of closure 
+variables $\Sigma$ at any nesting depth (e.g., a free variable might be closed by a binding which is defined at any 
+enclosing scope).
+
+We will start by illustrating the typing rules for expressions. A constant has an empty type, and does not change
+the stack. For variables, there are three different cases. In $\ruleName{var1}$, a variable is evaluated which is
+already bound by the current scope $\Gamma$. Therefore, its type can be read from the environment, and the
+variable itself is added to the set of closure variables at the current scope (to circumvent the issue explained in
+Section~\ref{sec:captured-vars}). If the variable is not bound in the current environment, it is typed at the
+surrounding scope as shown in $\ruleName{var2}$. The base-case is illustrated by $\ruleName{var3}$, where a variable
+is typed at the global scope (i.e. $\carrow{0}$). If the variable is not defined at the global scope either, it receives
+itself as an open term type.
+
+Lambdas introduce a new frame onto the stack, where the set of closure variables is empty, and the environment only
+maps the bound parameters of the lambda to empty open types. The body of the lambda term is then typed at a nested
+scope (i.e., $\carrow{n+1}$).
+
+For function application, two different rules apply. If the function application happens at global scope (i.e.,
+$\carrow{0}$), then all terms of the application must have empty open types (i.e., they cannot depend on variables
+that are not yet defined). If the application is inside a nested scope (e.g., under a \pyinline{def} or \pyinline{lambda})
+then each individual term is typed in sequence, where the returned type is then the union of the open term types, and
+the returned stack the one of the last typing judgement.
+
+For statements, the $\ruleName{pass}$ is trivial. For an assignment, the assigned variable cannot be part of the set of
+closure variables at the current scoping level. The returned type is the type of the right-hand side expression without
+the name currently being defined. The function $\mathrm{close}$ removes the second argument from all bindings in the
+updated environment.
+
+The rule for function definition $\ruleName{def}$ works similarly to the one for lambda expressions, with the added step of
+closing the environment by the function name $f$ in the returned environment stack.
+
+The rules for return and empty return are trivial again, they have a restriction on the nesting depth, so that they can only
+appear inside function definitions and not on a global scope.
+
+The rule for statement sequence is also trivial.
+
 \input{fig/open-term-typing}
 
 \subsection{Unsupported Python features}

--- a/PurePy-spec.tex
+++ b/PurePy-spec.tex
@@ -451,6 +451,10 @@ A \pyinline{return} statement without an expression is equivalent to \pyinline{r
 A function whose body $s$ assigns rather than returns is equivalent to a function whose body is $s$ followed
 by \pyinline{return None}. This ensures every function returns, even if it is not explicitly specified.
 
+\subsubsection{Late binding and mutual recursion}
+
+\input{fig/open-term-typing}
+
 \subsection{Unsupported Python features}
 
 The following Python features are excluded from \PurePy as they are incompatible with purity or

--- a/fig/open-term-typing.tex
+++ b/fig/open-term-typing.tex
@@ -1,0 +1,137 @@
+\begin{figure}
+\begin{subfigure}{\textwidth}
+\small
+\begin{center}
+\begin{tabular}{rcll}
+$\tau$ & $\subseteq$ & $\mathbb{V}$ & (open term type) \\
+$\Psi$ & $::=$ & $\Sigma \times \Gamma$ & (closure frame) \\
+$\Sigma$ & $::=$ & $\{ x \}$ & (closure variables) \\
+$\Gamma$ & $::=$ & $\mathbb{V} \rightarrow \mathcal{P}(\mathbb{V})$ & (closure environment) \\
+$\Delta$ & $::=$ & $\Delta : \Gamma$ & (closure frame stack) \\
+ & $\mid$ & $\varnothing$ & (empty stack)
+\end{tabular}
+\end{center}
+\end{subfigure}
+\caption{Open-term types}
+
+\begin{subfigure}{\textwidth}
+\flushleft \shadebox{$\Delta \vdash s \carrow{n} \tau, \Delta'$}
+\begin{mathpar}
+\inferrule*[lab={\ruleName{pass}}]
+{
+    \strut
+}
+{
+    \Delta \vdash \exPass \carrow{n} \Delta
+}
+\and%
+\inferrule*[lab={\ruleName{assign}}]
+{
+    x \notin \Sigma \qquad \Delta : (\Sigma, \Gamma) \vdash e \carrow{n} \tau, \Delta' : (\Sigma', \Gamma')  
+}
+{
+    \Delta : (\Sigma, \Gamma) \vdash \exAssign{x}{e} \carrow{n} \gamma \setminus \{ x \},  
+    \Delta' : (\Sigma', \Gamma'[x \mapsto \gamma \setminus \{ x \}]) 
+}
+\and%
+\inferrule*[lab={\ruleName{def}}]
+{
+    \Delta : (\varnothing, [f \mapsto \varnothing, \overline{x} \mapsto \varnothing]) \vdash s \carrow{n+1} \tau, 
+    \Delta' : (\Sigma', \Gamma') : \underline{\;\;}
+}
+{
+    \Delta \vdash \exDef{f}{\bar{x}}{s} \carrow{n} \tau, \Delta' : (\Sigma', \Gamma'[f \mapsto \tau])
+}
+\and%
+\inferrule*[lab={\ruleName{return}}]
+{
+    n > 0 \qquad \Delta \vdash e \carrow{n} \tau, \Delta'
+}
+{
+    \Delta \vdash \exReturn{e} \carrow{n} \tau, \Delta'
+}
+\and%
+\inferrule*[lab={\ruleName{returnNone}}]
+{
+    n > 0
+}
+{
+    \Delta \vdash \exReturnNone \carrow{n} \varnothing, \Delta
+}
+\and%
+\inferrule*[lab={\ruleName{seq}}]
+{
+    \Delta \vdash s_1 \carrow{n} \tau_1, \Delta' \qquad \Delta' \vdash s_2 \carrow{n} \tau_2, \Delta''
+}
+{
+    \Delta \vdash \exSeq{s_1}{s_2} \carrow{n} \tau_1 \cup \tau_2, \Delta''
+}
+\end{mathpar}
+\end{subfigure}
+\caption{Open statements typing rules}
+
+\begin{subfigure}{\textwidth}
+\flushleft \shadebox{$\Delta \vdash e \carrow{n} \tau, \Delta'$}
+\begin{mathpar}
+\small
+\inferrule*[lab={\ruleName{const}}]
+{
+    \strut
+}
+{
+    \Delta \vdash n \carrow{n} \varnothing, \Delta
+}
+\and%
+\inferrule*[lab={\ruleName{var1}}]
+{
+    x \in \mathrm{dom}(\Gamma)
+}
+{
+    \Delta : (\Sigma, \Gamma) \vdash x \carrow{n} \Gamma (x), \Delta : (\Sigma \cup \{ x \}, \Gamma)
+}
+\and%
+\inferrule*[lab={\ruleName{var2}}]
+{
+    x \notin \mathrm{dom}(\Gamma) \qquad \Delta \vdash x \carrow{n-1} \tau, \Delta'
+}
+{
+    \Delta : \Psi \vdash x \carrow{n} \tau, \Delta' : \Psi
+}
+\and%
+\inferrule*[lab={\ruleName{var3}}]
+{
+    x \notin \mathrm{dom}(\Gamma)
+}
+{
+    \varnothing : (\Sigma, \Gamma) \vdash x \carrow{0} \varnothing, \varnothing : (\Sigma, \Gamma) 
+}
+\and%
+\inferrule*[lab={\ruleName{lambda}}]
+{
+    \Delta : (\varnothing, [\overline{x} \mapsto \varnothing]) \vdash e \carrow{n+1} \tau, \Delta'
+}
+{
+    \Delta \vdash \exLambda{\overline{x}}{e} \carrow{n} \tau, \Delta'
+}
+\and%
+\inferrule*[lab={\ruleName{funcApp1}}]
+{
+    \forall i: \Delta \vdash e_i \carrow{0} \varnothing, \Delta
+}
+{
+    \Delta \vdash e_1 (e_2, \dots, c_n) \carrow{0} \varnothing, \Delta
+}
+\and%
+\inferrule*[lab={\ruleName{funcApp2}}]
+{
+    \Delta \vdash e_1 \carrow{n} \gamma_1, \Delta^{[1]} \qquad \Delta^{[1]} \vdash e_2 \carrow{n} \gamma_2, 
+    \Delta^{[2]} \qquad \cdots
+}
+{
+    \Delta \vdash e_1 (e_2, \dots, e_n) \rightarrow  \bigcup \gamma_i, \Delta^{[n]}
+}
+\end{mathpar}
+\end{subfigure}
+\caption{Open expressions typing rules}
+\label{fig:open-term-typing}
+\end{figure}

--- a/fig/open-term-typing.tex
+++ b/fig/open-term-typing.tex
@@ -3,12 +3,11 @@
 \small
 \begin{center}
 \begin{tabular}{rcll}
-$\tau$ & $\subseteq$ & $\mathbb{V}$ & (open term type) \\
-$\Psi$ & $::=$ & $\Sigma \times \Gamma$ & (frame) \\
-$\Sigma$ & $::=$ & $\{ x \}$ & (closure variables) \\
-$\Gamma$ & $::=$ & $\mathbb{V} \rightarrow \mathcal{P}(\mathbb{V})$ & (environment) \\
-$\Delta$ & $::=$ & $\Delta : \Psi$ & (frame stack) \\
- & $\mid$ & $\varnothing$ & (empty stack)
+$\tau$ & $::=$ & $\{ \seq{x} \}$ & (open term type) \\
+$\Sigma$ & $::=$ & $\{ \seq{x} \}$ & (captured variables) \\
+$\Gamma$ & $::=$ & $\{ \seq{x : \tau} \}$ & (environment) \\
+$\Delta$ & $::=$ & $\Delta : (\Sigma, \Gamma)$ & (frame stack) \\
+& $\mid$ & $\varnothing$ &  
 \end{tabular}
 \end{center}
 \end{subfigure}
@@ -24,7 +23,15 @@ $\Delta$ & $::=$ & $\Delta : \Psi$ & (frame stack) \\
     \strut
 }
 {
-    \Delta \vdash n \carrow{n} \varnothing, \Delta
+    \Delta \vdash c \carrow{n} \varnothing, \Delta
+}
+\and%
+\inferrule*[lab={\ruleName{lambda}}]
+{
+    \Delta : (\varnothing, [\overline{x} \mapsto \varnothing]) \vdash e \carrow{n+1} \tau, \underline{\;\;}
+}
+{
+    \Delta \vdash \exLambda{\overline{x}}{e} \carrow{n} \tau, \Delta
 }
 \and%
 \inferrule*[lab={\ruleName{var1}}]
@@ -32,31 +39,23 @@ $\Delta$ & $::=$ & $\Delta : \Psi$ & (frame stack) \\
     x \in \mathrm{dom}(\Gamma)
 }
 {
-    \Delta : (\Sigma, \Gamma) \vdash x \carrow{n} \Gamma (x), \Delta : (\Sigma \cup \{ x \}, \Gamma)
+    \Delta : (\Sigma, \Gamma) \vdash x \carrow{n} \Gamma (x), \Delta : (\Sigma, \Gamma)
 }
 \and%
 \inferrule*[lab={\ruleName{var2}}]
 {
-    x \notin \mathrm{dom}(\Gamma) \qquad \Delta \vdash x \carrow{n-1} \tau, \Delta'
+    x \notin \mathrm{dom}(\Gamma) \qquad \mathrm{bound}(\Delta, x) = \hat{\Gamma}
 }
 {
-    \Delta : \Psi \vdash x \carrow{n} \tau, \Delta' : \Psi
+    \Delta : (\Sigma, \Gamma) \vdash x \carrow{n} \hat{\Gamma}(x), \mathrm{mark}(\Delta, x) : (\Sigma, \Gamma)
 }
 \and%
 \inferrule*[lab={\ruleName{var3}}]
 {
-    x \notin \mathrm{dom}(\Gamma)
+    n > 0 \qquad x \notin \mathrm{dom}(\Gamma) \qquad \nexists\, \hat{\Gamma} \,.\, \mathrm{bound}(\Delta, x) = \hat{\Gamma}
 }
 {
-    \varnothing : (\Sigma, \Gamma) \vdash x \carrow{0} \{x\}, \varnothing : (\Sigma, \Gamma) 
-}
-\and%
-\inferrule*[lab={\ruleName{lambda}}]
-{
-    \Delta : (\varnothing, [\overline{x} \mapsto \varnothing]) \vdash e \carrow{n+1} \tau, \Delta'
-}
-{
-    \Delta \vdash \exLambda{\overline{x}}{e} \carrow{n} \tau, \Delta'
+    \Delta : (\Sigma, \Gamma) \vdash x \carrow{n} \{x\}, \Delta : (\Sigma \cup \{ x \}, \Gamma)
 }
 \and%
 \inferrule*[lab={\ruleName{funcApp1}}]
@@ -69,11 +68,10 @@ $\Delta$ & $::=$ & $\Delta : \Psi$ & (frame stack) \\
 \and%
 \inferrule*[lab={\ruleName{funcApp2}}]
 {
-    n > 0 \qquad \Delta \vdash e_1 \carrow{n} \gamma_1, \Delta^{[1]} \qquad \Delta^{[1]} \vdash e_2 \carrow{n} \gamma_2, 
-    \Delta^{[2]} \qquad \cdots
+    n > 0 \qquad \forall_{i = 1 \dots n} : \Delta_{[i-1]} \vdash e_i \carrow{n} \tau_i, \Delta_{[i]}
 }
 {
-    \Delta \vdash e_1 (e_2, \dots, e_n) \carrow{n}  \bigcup \gamma_i, \Delta^{[n]}
+    \Delta_{[0]} \vdash e_1 (e_2, \dots, e_n) \carrow{n}  \bigcup \tau_i, \Delta_{[n]}
 }
 \end{mathpar}
 \end{subfigure}
@@ -89,25 +87,24 @@ $\Delta$ & $::=$ & $\Delta : \Psi$ & (frame stack) \\
     \strut
 }
 {
-    \Delta \vdash \exPass \carrow{n} \Delta
+    \Delta \vdash \exPass \carrow{n} \varnothing, \Delta
 }
 \and%
 \inferrule*[lab={\ruleName{assign}}]
 {
-    x \notin \Sigma \qquad \Delta : (\Sigma, \Gamma) \vdash e \carrow{n} \tau, \Delta' : (\Sigma', \Gamma')  
+    (\nexists\, y \,.\, x \in \Gamma(y)) \lor \lnot\, \mathrm{captured}(\Delta, x) \qquad \Delta : (\Sigma, \Gamma) \vdash e \carrow{n} \tau, \Delta' : (\Sigma', \Gamma')
 }
 {
-    \Delta : (\Sigma, \Gamma) \vdash \exAssign{x}{e} \carrow{n} \gamma \setminus \{ x \},  
-    \Delta' : (\Sigma', \mathrm{close}(\Gamma'[x \mapsto \gamma], x)) 
+    \Delta \vdash \exAssign{x}{e} \carrow{n} \tau \setminus \{ x \}, \Delta' : (\Sigma', \mathrm{close}(\Gamma'[x \mapsto \tau], x))
 }
 \and%
 \inferrule*[lab={\ruleName{if1}}]
 {
-    n > 0 \qquad \Delta \vdash e_1 \carrow{n} \gamma_1, \Delta^{[1]} \qquad \Delta^{[1]} \vdash s_1 \carrow{n} \gamma_2, 
-    \Delta^{[2]} \qquad \cdots \qquad \Delta^{[n-1]} \vdash e_n \carrow{n} \gamma_n,  \Delta^{[n]}
+    n > 0 \qquad \Delta \vdash e_1 \carrow{n} \gamma_1, \Delta_{[1]} \qquad \Delta_{[1]} \vdash s_1 \carrow{n} \gamma_2, 
+    \Delta_{[2]} \qquad \cdots \qquad \Delta_{[n-1]} \vdash e_n \carrow{n} \gamma_n,  \Delta_{[n]}
 }
 {
-    \Delta \vdash \exIfElse{e_1}{s_1}{[\exElif{e_i}{s_i}]}{e_n} \carrow{n} \bigcup \gamma_i, \Delta^{[n]}
+    \Delta \vdash \exIfElse{e_1}{s_1}{[\exElif{e_i}{s_i}]}{e_n} \carrow{n} \bigcup \gamma_i, \Delta_{[n]}
 }
 \and%
 \inferrule*[lab={\ruleName{if2}}]
@@ -154,4 +151,73 @@ $\Delta$ & $::=$ & $\Delta : \Psi$ & (frame stack) \\
 \end{subfigure}
 \caption{Open statements typing rules}
 \label{fig:open-stmts-type-rules}
+\end{figure}
+
+\begin{figure}
+\begin{mathpar}
+\footnotesize
+\inferrule
+{
+    x \in \Sigma
+}
+{
+    \mathrm{captured}(\Delta : (\Sigma, \Gamma), x)
+}
+\and%
+\inferrule
+{
+    x \notin \Sigma \qquad \mathrm{captured}(\Delta, x)
+}
+{
+    \mathrm{captured}(\Delta : (\Sigma, \Gamma), x)
+}
+\end{mathpar}
+\newline
+\begin{mathpar}
+\footnotesize
+\inferrule
+{
+    x \in \mathrm{dom}(\Gamma)
+}
+{
+    \mathrm{bound}(\Delta : (\Sigma, \Gamma), x) = \Gamma
+}
+\and%
+\inferrule
+{
+    x \notin \mathrm{dom}(\Gamma) \qquad \mathrm{bound}(\Delta, x) = \hat{\Gamma}
+}
+{
+    \mathrm{bound}(\Delta : (\Sigma, \Gamma), x) = \hat{\Gamma}
+}
+\end{mathpar}
+\newline
+\begin{mathpar}
+\footnotesize
+\inferrule
+{
+    \strut
+}
+{
+    \mathrm{mark}(\varnothing, x) = \varnothing
+}
+\and%
+\inferrule
+{
+    x \in \mathrm{dom}(\Gamma)
+}
+{
+    \mathrm{mark}(\Delta : (\Sigma, \Gamma), x) = \Delta : (\Sigma \cup \{ x \}, \Gamma)
+}
+\and%
+\inferrule
+{
+    x \notin \mathrm{dom}(\Gamma) \qquad \mathrm{mark}(\Delta, x) = \Delta'
+}
+{
+    \mathrm{mark}(\Delta : (\Sigma, \Gamma), x) = \Delta' : (\Sigma, \Gamma)
+}
+\end{mathpar}
+\caption{Auxiliary definitions for open term typing}
+\label{fig:var-capture}
 \end{figure}

--- a/fig/open-term-typing.tex
+++ b/fig/open-term-typing.tex
@@ -4,15 +4,16 @@
 \begin{center}
 \begin{tabular}{rcll}
 $\tau$ & $\subseteq$ & $\mathbb{V}$ & (open term type) \\
-$\Psi$ & $::=$ & $\Sigma \times \Gamma$ & (closure frame) \\
+$\Psi$ & $::=$ & $\Sigma \times \Gamma$ & (frame) \\
 $\Sigma$ & $::=$ & $\{ x \}$ & (closure variables) \\
-$\Gamma$ & $::=$ & $\mathbb{V} \rightarrow \mathcal{P}(\mathbb{V})$ & (closure environment) \\
-$\Delta$ & $::=$ & $\Delta : \Gamma$ & (closure frame stack) \\
+$\Gamma$ & $::=$ & $\mathbb{V} \rightarrow \mathcal{P}(\mathbb{V})$ & (environment) \\
+$\Delta$ & $::=$ & $\Delta : \Psi$ & (frame stack) \\
  & $\mid$ & $\varnothing$ & (empty stack)
 \end{tabular}
 \end{center}
 \end{subfigure}
 \caption{Open-term types}
+\label{fig:open-term-types}
 
 \begin{subfigure}{\textwidth}
 \flushleft \shadebox{$\Delta \vdash s \carrow{n} \tau, \Delta'$}
@@ -31,7 +32,7 @@ $\Delta$ & $::=$ & $\Delta : \Gamma$ & (closure frame stack) \\
 }
 {
     \Delta : (\Sigma, \Gamma) \vdash \exAssign{x}{e} \carrow{n} \gamma \setminus \{ x \},  
-    \Delta' : (\Sigma', \Gamma'[x \mapsto \gamma \setminus \{ x \}]) 
+    \Delta' : (\Sigma', \mathrm{close}(\Gamma'[x \mapsto \gamma], x)) 
 }
 \and%
 \inferrule*[lab={\ruleName{def}}]
@@ -40,7 +41,7 @@ $\Delta$ & $::=$ & $\Delta : \Gamma$ & (closure frame stack) \\
     \Delta' : (\Sigma', \Gamma') : \underline{\;\;}
 }
 {
-    \Delta \vdash \exDef{f}{\bar{x}}{s} \carrow{n} \tau, \Delta' : (\Sigma', \Gamma'[f \mapsto \tau])
+    \Delta \vdash \exDef{f}{\bar{x}}{s} \carrow{n} \tau, \Delta' : (\Sigma', \mathrm{close}(\Gamma'[f \mapsto \tau], f))
 }
 \and%
 \inferrule*[lab={\ruleName{return}}]
@@ -69,6 +70,7 @@ $\Delta$ & $::=$ & $\Delta : \Gamma$ & (closure frame stack) \\
 \end{mathpar}
 \end{subfigure}
 \caption{Open statements typing rules}
+\label{fig:open-stmts-type-rules}
 
 \begin{subfigure}{\textwidth}
 \flushleft \shadebox{$\Delta \vdash e \carrow{n} \tau, \Delta'$}
@@ -103,7 +105,7 @@ $\Delta$ & $::=$ & $\Delta : \Gamma$ & (closure frame stack) \\
     x \notin \mathrm{dom}(\Gamma)
 }
 {
-    \varnothing : (\Sigma, \Gamma) \vdash x \carrow{0} \varnothing, \varnothing : (\Sigma, \Gamma) 
+    \varnothing : (\Sigma, \Gamma) \vdash x \carrow{0} \{x\}, \varnothing : (\Sigma, \Gamma) 
 }
 \and%
 \inferrule*[lab={\ruleName{lambda}}]
@@ -124,14 +126,14 @@ $\Delta$ & $::=$ & $\Delta : \Gamma$ & (closure frame stack) \\
 \and%
 \inferrule*[lab={\ruleName{funcApp2}}]
 {
-    \Delta \vdash e_1 \carrow{n} \gamma_1, \Delta^{[1]} \qquad \Delta^{[1]} \vdash e_2 \carrow{n} \gamma_2, 
+    n > 0 \qquad \Delta \vdash e_1 \carrow{n} \gamma_1, \Delta^{[1]} \qquad \Delta^{[1]} \vdash e_2 \carrow{n} \gamma_2, 
     \Delta^{[2]} \qquad \cdots
 }
 {
-    \Delta \vdash e_1 (e_2, \dots, e_n) \rightarrow  \bigcup \gamma_i, \Delta^{[n]}
+    \Delta \vdash e_1 (e_2, \dots, e_n) \carrow{n}  \bigcup \gamma_i, \Delta^{[n]}
 }
 \end{mathpar}
 \end{subfigure}
 \caption{Open expressions typing rules}
-\label{fig:open-term-typing}
+\label{fig:open-expr-type-rules}
 \end{figure}

--- a/fig/open-term-typing.tex
+++ b/fig/open-term-typing.tex
@@ -12,70 +12,13 @@ $\Delta$ & $::=$ & $\Delta : \Psi$ & (frame stack) \\
 \end{tabular}
 \end{center}
 \end{subfigure}
-\caption{Open-term types}
+\caption{Open term types}
 \label{fig:open-term-types}
-
-\begin{subfigure}{\textwidth}
-\flushleft \shadebox{$\Delta \vdash s \carrow{n} \tau, \Delta'$}
-\begin{mathpar}
-\inferrule*[lab={\ruleName{pass}}]
-{
-    \strut
-}
-{
-    \Delta \vdash \exPass \carrow{n} \Delta
-}
-\and%
-\inferrule*[lab={\ruleName{assign}}]
-{
-    x \notin \Sigma \qquad \Delta : (\Sigma, \Gamma) \vdash e \carrow{n} \tau, \Delta' : (\Sigma', \Gamma')  
-}
-{
-    \Delta : (\Sigma, \Gamma) \vdash \exAssign{x}{e} \carrow{n} \gamma \setminus \{ x \},  
-    \Delta' : (\Sigma', \mathrm{close}(\Gamma'[x \mapsto \gamma], x)) 
-}
-\and%
-\inferrule*[lab={\ruleName{def}}]
-{
-    \Delta : (\varnothing, [f \mapsto \varnothing, \overline{x} \mapsto \varnothing]) \vdash s \carrow{n+1} \tau, 
-    \Delta' : (\Sigma', \Gamma') : \underline{\;\;}
-}
-{
-    \Delta \vdash \exDef{f}{\bar{x}}{s} \carrow{n} \tau, \Delta' : (\Sigma', \mathrm{close}(\Gamma'[f \mapsto \tau], f))
-}
-\and%
-\inferrule*[lab={\ruleName{return}}]
-{
-    n > 0 \qquad \Delta \vdash e \carrow{n} \tau, \Delta'
-}
-{
-    \Delta \vdash \exReturn{e} \carrow{n} \tau, \Delta'
-}
-\and%
-\inferrule*[lab={\ruleName{returnNone}}]
-{
-    n > 0
-}
-{
-    \Delta \vdash \exReturnNone \carrow{n} \varnothing, \Delta
-}
-\and%
-\inferrule*[lab={\ruleName{seq}}]
-{
-    \Delta \vdash s_1 \carrow{n} \tau_1, \Delta' \qquad \Delta' \vdash s_2 \carrow{n} \tau_2, \Delta''
-}
-{
-    \Delta \vdash \exSeq{s_1}{s_2} \carrow{n} \tau_1 \cup \tau_2, \Delta''
-}
-\end{mathpar}
-\end{subfigure}
-\caption{Open statements typing rules}
-\label{fig:open-stmts-type-rules}
 
 \begin{subfigure}{\textwidth}
 \flushleft \shadebox{$\Delta \vdash e \carrow{n} \tau, \Delta'$}
 \begin{mathpar}
-\small
+\footnotesize
 \inferrule*[lab={\ruleName{const}}]
 {
     \strut
@@ -136,4 +79,79 @@ $\Delta$ & $::=$ & $\Delta : \Psi$ & (frame stack) \\
 \end{subfigure}
 \caption{Open expressions typing rules}
 \label{fig:open-expr-type-rules}
+
+\begin{subfigure}{\textwidth}
+\flushleft \shadebox{$\Delta \vdash s \carrow{n} \tau, \Delta'$}
+\begin{mathpar}
+\footnotesize
+\inferrule*[lab={\ruleName{pass}}]
+{
+    \strut
+}
+{
+    \Delta \vdash \exPass \carrow{n} \Delta
+}
+\and%
+\inferrule*[lab={\ruleName{assign}}]
+{
+    x \notin \Sigma \qquad \Delta : (\Sigma, \Gamma) \vdash e \carrow{n} \tau, \Delta' : (\Sigma', \Gamma')  
+}
+{
+    \Delta : (\Sigma, \Gamma) \vdash \exAssign{x}{e} \carrow{n} \gamma \setminus \{ x \},  
+    \Delta' : (\Sigma', \mathrm{close}(\Gamma'[x \mapsto \gamma], x)) 
+}
+\and%
+\inferrule*[lab={\ruleName{if1}}]
+{
+    n > 0 \qquad \Delta \vdash e_1 \carrow{n} \gamma_1, \Delta^{[1]} \qquad \Delta^{[1]} \vdash s_1 \carrow{n} \gamma_2, 
+    \Delta^{[2]} \qquad \cdots \qquad \Delta^{[n-1]} \vdash e_n \carrow{n} \gamma_n,  \Delta^{[n]}
+}
+{
+    \Delta \vdash \exIfElse{e_1}{s_1}{[\exElif{e_i}{s_i}]}{e_n} \carrow{n} \bigcup \gamma_i, \Delta^{[n]}
+}
+\and%
+\inferrule*[lab={\ruleName{if2}}]
+{
+     \forall i: \Delta \vdash e_i / s_i \carrow{0} \varnothing, \Delta
+}
+{
+    \Delta \vdash \exIfElse{e_1}{s_1}{[\exElif{e_i}{s_i}]}{e_n} \carrow{0} \varnothing, \Delta
+}
+\and%
+\inferrule*[lab={\ruleName{def}}]
+{
+    \Delta : (\varnothing, [f \mapsto \varnothing, \overline{x} \mapsto \varnothing]) \vdash s \carrow{n+1} \tau, 
+    \Delta' : (\Sigma', \Gamma') : \underline{\;\;}
+}
+{
+    \Delta \vdash \exDef{f}{\bar{x}}{s} \carrow{n} \tau, \Delta' : (\Sigma', \mathrm{close}(\Gamma'[f \mapsto \tau], f))
+}
+\and%
+\inferrule*[lab={\ruleName{return}}]
+{
+    n > 0 \qquad \Delta \vdash e \carrow{n} \tau, \Delta'
+}
+{
+    \Delta \vdash \exReturn{e} \carrow{n} \tau, \Delta'
+}
+\and%
+\inferrule*[lab={\ruleName{returnNone}}]
+{
+    n > 0
+}
+{
+    \Delta \vdash \exReturnNone \carrow{n} \varnothing, \Delta
+}
+\and%
+\inferrule*[lab={\ruleName{seq}}]
+{
+    \Delta \vdash s_1 \carrow{n} \tau_1, \Delta' \qquad \Delta' \vdash s_2 \carrow{n} \tau_2, \Delta''
+}
+{
+    \Delta \vdash \exSeq{s_1}{s_2} \carrow{n} \tau_1 \cup \tau_2, \Delta''
+}
+\end{mathpar}
+\end{subfigure}
+\caption{Open statements typing rules}
+\label{fig:open-stmts-type-rules}
 \end{figure}

--- a/test/var-capture/ill-formed/ex1.py
+++ b/test/var-capture/ill-formed/ex1.py
@@ -1,0 +1,6 @@
+def foo():
+    y = 11
+    def bar():
+        return y
+    y = 2
+    return bar()

--- a/test/var-capture/ill-formed/ex2.py
+++ b/test/var-capture/ill-formed/ex2.py
@@ -1,0 +1,7 @@
+def foo():
+    x = y
+    y = 10          # Error
+    return x
+
+y = 11
+print(foo())

--- a/test/var-capture/well-formed/ex1.py
+++ b/test/var-capture/well-formed/ex1.py
@@ -1,0 +1,8 @@
+def foo():
+    y = x
+    def bar():
+        return y
+    return bar()
+
+x = 10
+print(foo())

--- a/test/var-capture/well-formed/ex2.py
+++ b/test/var-capture/well-formed/ex2.py
@@ -1,0 +1,6 @@
+def foo():
+    x = lambda: y
+    y = 10  
+    return x
+
+print(foo()())

--- a/test/var-capture/well-formed/ex3.py
+++ b/test/var-capture/well-formed/ex3.py
@@ -1,0 +1,9 @@
+def foo():
+    x = y
+    def bar():
+        y = 10
+        return y
+    return bar()
+
+y = 2
+print(foo())

--- a/tex/macros.tex
+++ b/tex/macros.tex
@@ -62,3 +62,6 @@
 
 % open term typing arrow
 \newcommand{\carrow}[1]{\xrightarrow{\; #1\; }}
+
+% sequence of terms
+\newcommand{\seq}[1]{\vec{#1}}

--- a/tex/macros.tex
+++ b/tex/macros.tex
@@ -59,3 +59,6 @@
 % operational semantics
 \newcommand{\assigns}[1]{\mathsf{assigns}\;#1}
 \newcommand{\returns}[1]{\mathsf{returns}\;#1}
+
+% open term typing arrow
+\newcommand{\carrow}[1]{\xrightarrow{\; #1\; }}


### PR DESCRIPTION
This PR introduces a type system for ***open terms***, i.e., terms that depend on variables that are not yet defined.

This should fix #12 

TODO:
- evaluate the rules on the examples from #12 
- introduce more examples in the text to motivate certain design decisions
- possibly: implement a checker on-top of the `ast` module from the Python standard library