### PR TITLE
Imports as prefix of module body (#102)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@
 *.out
 agda/_build/
 .venv/
+__pycache__/
 
 .claude/settings.local.json

--- a/PurePy-spec.tex
+++ b/PurePy-spec.tex
@@ -264,13 +264,12 @@ which follow Python.
 A \PurePy \emph{program} $\langle E, \mathcal{M} \rangle$ consists of a finite map
 $\mathcal{M}$ from \emph{fully-qualified names} $M$ (\figref{syntax-stmt}) to \emph{modules} $m$ (each a sequence
 of top-level statements $t_1 \ldots t_{n+1}$), together with a designated \emph{entry point} $E \in
-\dom(\mathcal{M})$. The pair $\langle E, \mathcal{M} \rangle$ is fixed and ambient in all definitions that follow. The map $\mathcal{M}$ is prefix-closed: if $M \in \dom(\mathcal{M})$ then $\parents(M) \subseteq \dom(\mathcal{M})$. The top-level form $t$ (\figref{syntax-stmt}) extends the statement form $s$ with
-the \pyinline{import} and \pyinline{from} forms; these forms can therefore appear only at the
-top level of a module, not inside function bodies, conditional branches, or other nested contexts.
-This restriction prevents side-effects of module execution, currently divergence or runtime errors, from
-implicitly becoming side-effects of a function. A module executes at most once per program; the restriction
-keeps that execution at the top level, where its effects occur at known points rather than on whichever
-function call happens to trigger the import first. For any $(M \mapsto b) \in
+\dom(\mathcal{M})$. $\mathcal{M}$ always includes the predefined modules of \figref{predefined} and is prefix-closed:
+if $M \in \dom(\mathcal{M})$ then $\parents(M) \subseteq \dom(\mathcal{M})$. The pair $\langle E, \mathcal{M} \rangle$
+is fixed and ambient in all definitions that follow.
+The top-level form $t$ (\figref{syntax-stmt}) extends the statement form $s$ with the \pyinline{import} and
+\pyinline{from} forms; these forms can therefore appear only as a contiguous prefix of a module body, before any
+other statement. This confines module-loading side-effects (currently only divergence or runtime errors) to a single zone at the start of each module body. For any $(M \mapsto b) \in
 \mathcal{M}$, well-formedness of $b$ is checked under the initial context $\Gamma_M = \Gamma_{\pyinline{builtins}}
 \runion \set{\text{\pyinline{__name__}} \mapsto \statusDefAssigned}$, where $\Gamma_{\pyinline{builtins}}$
 binds at status $\statusDefAssigned$ the names of the predefined module \pyinline{builtins} (\figref{predefined}).
@@ -303,8 +302,7 @@ prefixes of a fully-qualified name.
 The \emph{dependency graph} $G_{\mathcal{M}}$ of a module map has an edge $(M, M')$ iff
 $M' \in \imports(\mathcal{M}(M)) \cup \parents(M)$. Program well-formedness (\figref{modules}) requires every
 module in $\mathcal{M}$ to be well-formed in its initial context, every imported name to be in
-$\dom(\mathcal{M})$, and $G_{\mathcal{M}}$ to be acyclic. The predefined module \pyinline{builtins} is required
-to be in $\dom(\mathcal{M})$; the runtime provides it.
+$\dom(\mathcal{M})$, and $G_{\mathcal{M}}$ to be acyclic.
 
 \subsection{Well-formedness}
 

--- a/fig/eval-modules.tex
+++ b/fig/eval-modules.tex
@@ -1,5 +1,5 @@
 \begin{figure}
-\flushleft \shadebox{$\mu, \rho, m \Rightarrow \mu', r$}
+\flushleft \shadebox{$\mu, \rho, m \Rightarrow \mu', \rho'$}
 \begin{mathpar}
 \small
 \inferrule*[lab={\ruleName{eval-empty}}]
@@ -7,24 +7,24 @@
   \strut
 }
 {
-  \mu, \rho, \varepsilon \Rightarrow \mu, \assigns{\varnothing}
-}
-\and
-\inferrule*[lab={\ruleName{eval-stmt}}]
-{
-  \rho, s \Rightarrow r
-}
-{
-  \mu, \rho, s \Rightarrow \mu, r
+  \mu, \rho, \varepsilon \Rightarrow \mu, \varnothing
 }
 \and
 \inferrule*[lab={\ruleName{eval-seq}}]
 {
-  \mu, \rho, t \Rightarrow \mu', \assigns{\rho'} \\
-  \mu', \rho \runion \rho', m \Rightarrow \mu'', r
+  \mu, \rho, t \Rightarrow \mu', \rho_t \\
+  \mu', \rho \runion \rho_t, m \Rightarrow \mu'', \rho_m
 }
 {
-  \mu, \rho, t \cons m \Rightarrow \mu'', \assigns{\rho'} \runion r
+  \mu, \rho, t \cons m \Rightarrow \mu'', \rho_t \runion \rho_m
+}
+\and
+\inferrule*[lab={\ruleName{eval-block}}]
+{
+  \rho, b \Rightarrow \assigns{\rho'}
+}
+{
+  \mu, \rho, b \Rightarrow \mu, \rho'
 }
 \and
 \inferrule*[lab={\ruleName{eval-import}}]
@@ -33,7 +33,7 @@
   M = x_1.x_2.\ldots.x_{n+1}
 }
 {
-  \mu, \rho, \exImport{M} \Rightarrow \mu', \assigns{\set{x_1 \mapsto \mu'(x_1)}}
+  \mu, \rho, \exImport{M} \Rightarrow \mu', \set{x_1 \mapsto \mu'(x_1)}
 }
 \and
 \inferrule*[lab={\ruleName{eval-from-import}}]
@@ -42,7 +42,7 @@
   \mu'(M) = \exObj{\rho''}
 }
 {
-  \mu, \rho, \exFromImport{M}{x_1, \ldots, x_{n+1}} \Rightarrow \mu', \assigns{\set{x_1 \mapsto \rho''(x_1), \ldots, x_{n+1} \mapsto \rho''(x_{n+1})}}
+  \mu, \rho, \exFromImport{M}{x_1, \ldots, x_{n+1}} \Rightarrow \mu', \set{x_1 \mapsto \rho''(x_1), \ldots, x_{n+1} \mapsto \rho''(x_{n+1})}
 }
 \end{mathpar}
 
@@ -62,7 +62,7 @@
 \inferrule*[lab={\ruleName{load-unqualified}}]
 {
   x \notin \dom(\mu) \\
-  \mu, \rho_x, \mathcal{M}(x) \Rightarrow \mu', \assigns{\rho}
+  \mu, \rho_x, \mathcal{M}(x) \Rightarrow \mu', \rho
 }
 {
   \mu, x \Rightarrow_{\mathsf{load}} \mu' \runion \set{x \mapsto \exObj{\rho}}
@@ -72,7 +72,7 @@
 {
   M.x \notin \dom(\mu) \\
   \mu, M \Rightarrow_{\mathsf{load}} \mu' \\
-  \mu', \rho_{M.x}, \mathcal{M}(M.x) \Rightarrow \mu'', \assigns{\rho}
+  \mu', \rho_{M.x}, \mathcal{M}(M.x) \Rightarrow \mu'', \rho
 }
 {
   \mu, M.x \Rightarrow_{\mathsf{load}} \mu'' \runion \set{M.x \mapsto \exObj{\rho}}
@@ -86,7 +86,7 @@
 \small
 \inferrule*[lab={\ruleName{eval-program}}]
 {
-  \varnothing, \rho_E, \mathcal{M}(E) \Rightarrow \mu, \assigns{\rho}
+  \varnothing, \rho_E, \mathcal{M}(E) \Rightarrow \mu, \rho
 }
 {
   \langle E, \mathcal{M} \rangle \Rightarrow 0

--- a/fig/modules.tex
+++ b/fig/modules.tex
@@ -18,7 +18,7 @@
 \small
 \inferrule*[lab={\ruleName{module}}]
 {
-  \Gamma_M \vdash \mathcal{M}(M) : \Assigns{\Delta} \\
+  \Gamma_M \vdash \mathcal{M}(M) : \Delta \\
   \imports(\mathcal{M}(M)) \subseteq \dom(\mathcal{M})
 }
 {
@@ -31,7 +31,6 @@
 \small
 \inferrule*[lab={\ruleName{program}}]
 {
-  \pyinline{builtins} \in \dom(\mathcal{M}) \\
   \vdash_{\mathcal{M}} M_i \quad (\forall M_i \in \dom(\mathcal{M})) \\
   G_{\mathcal{M}} \text{ acyclic}
 }

--- a/fig/syntax.tex
+++ b/fig/syntax.tex
@@ -16,11 +16,10 @@ $s$ & $::=$ & $\exPass$ & (Pass) \\
    \\[3mm]
 $b$ & $::=$ & $s_1 \;\ldots\; s_{n+1}$ & (Block)
    \\[3mm]
-$t$ & $::=$ & $s$ & (Stmt) \\
-    & $\mid$ & $\exImport{M}$ & (Import) \\
+$t$ & $::=$ & $\exImport{M}$ & (Import) \\
     & $\mid$ & $\exFromImport{M}{x_1, \ldots, x_{n+1}}$ & (FromImport)
    \\[3mm]
-$m$ & $::=$ & $t_1 \;\ldots\; t_n$ & (Module)
+$m$ & $::=$ & $t_1 \;\ldots\; t_n \; s_1 \;\ldots\; s_k$ & (Module)
    \\[3mm]
 $M$ & $::=$ & $x_1.x_2.\ldots.x_{n+1}$ & (FullyQualifiedName)
    \\[3mm]

--- a/fig/well-formed-top.tex
+++ b/fig/well-formed-top.tex
@@ -1,5 +1,5 @@
 \begin{figure}
-\flushleft \shadebox{$\Gamma \vdash m : R$}
+\flushleft \shadebox{$\Gamma \vdash m : \Delta$}
 \begin{mathpar}
 \small
 \inferrule*[lab={\ruleName{empty}}]
@@ -7,7 +7,7 @@
   \strut
 }
 {
-  \Gamma \vdash \varepsilon : \Assigns{\varnothing}
+  \Gamma \vdash \varepsilon : \varnothing
 }
 \and
 \inferrule*[lab={\ruleName{import}}]
@@ -15,7 +15,7 @@
   M = x_1.x_2.\ldots.x_{n+1}
 }
 {
-  \Gamma \vdash \exImport{M} : \Assigns{\statusDefAssigned(\set{x_1})}
+  \Gamma \vdash \exImport{M} : \statusDefAssigned(\set{x_1})
 }
 \and
 \inferrule*[lab={\ruleName{from-import}}]
@@ -23,19 +23,27 @@
   \strut
 }
 {
-  \Gamma \vdash \exFromImport{M}{x_1, \ldots, x_{n+1}} : \Assigns{\statusDefAssigned(\set{x_1, \ldots, x_{n+1}})}
+  \Gamma \vdash \exFromImport{M}{x_1, \ldots, x_{n+1}} : \statusDefAssigned(\set{x_1, \ldots, x_{n+1}})
 }
 \and
 \inferrule*[lab={\ruleName{seq}}]
 {
-  \Gamma \vdash t : \Assigns{\Delta} \\
-  \Gamma \runion \Delta \vdash m : R \\
+  \Gamma \vdash t : \Delta \\
+  \Gamma \runion \Delta \vdash m : \Delta' \\
   \capturesS(t) \cap \assignsS(m) = \varnothing
 }
 {
-  \Gamma \vdash t \cons m : \Assigns{\Delta} \runion R
+  \Gamma \vdash t \cons m : \Delta \runion \Delta'
+}
+\and
+\inferrule*[lab={\ruleName{block}}]
+{
+  \Gamma \vdash b : \Assigns{\Delta}
+}
+{
+  \Gamma \vdash b : \Delta
 }
 \end{mathpar}
-\caption{Module body $m$ is well-formed in $\Gamma$; when $t$ is a statement $s$, the rules of \figref{well-formed} apply}
+\caption{Module body $m$ is well-formed in $\Gamma$}
 \label{fig:well-formed-top}
 \end{figure}


### PR DESCRIPTION
Closes #102.

## Summary
- Grammar: \`t\` redefined to import-only (\`Import\` | \`FromImport\`); \`m ::= t_1 ... t_n s_1 ... s_k\`.
- Well-formedness for \`m\`: judgement form changes to \`Γ ⊢ m : Δ\` (no Assigns wrapper, since Returns is structurally impossible at module level); added \`block\` rule lifting the block judgement.
- Module evaluation: judgement form changes to \`μ, ρ, m ⇒ μ', ρ'\` (no result-type wrapper); added \`eval-block\` rule.
- Program rule: dropped \`builtins ∈ dom(𝓜)\` premise, since 𝓜 by definition includes the predefined modules.
- §2.2 prose: rationale rewritten (single restriction, not two separate confinements); inclusion of predefined modules folded into the prefix-closure sentence.

Impl + tests not in this PR (spec only).

## Test plan
- [ ] LaTeX rebuilds cleanly.
- [ ] Existing test suite still passes (no impl changes here).