### PR TITLE
Exclude wildcard imports

### DIFF
--- a/PurePy-spec.tex
+++ b/PurePy-spec.tex
@@ -265,9 +265,8 @@ of top-level statements $t_1 \ldots t_{n+1}$), together with a designated \emph{
 \dom(\mathcal{M})$. $\mathcal{M}$ always includes the predefined modules of \figref{predefined} and is prefix-closed:
 if $M \in \dom(\mathcal{M})$ then $\parents(M) \subseteq \dom(\mathcal{M})$. The pair $\langle E, \mathcal{M} \rangle$
 is fixed and ambient in all definitions that follow.
-The top-level form $t$ (\figref{syntax-stmt}) extends the statement form $s$ with the \pyinline{import} and
-\pyinline{from} forms; these forms can therefore appear only as a contiguous prefix of a module body, before any
-other statement. This confines module-loading side-effects (currently only divergence or runtime errors) to a single zone at the start of each module body. For any $(M \mapsto b) \in
+\pyinline{import} statements appear only as a contiguous prefix of a module body, before any other statement. This confines module-loading side-effects (currently only divergence or runtime
+errors) to a single zone at the start of each module body. For any $(M \mapsto b) \in
 \mathcal{M}$, well-formedness of $b$ is checked under the initial context $\Gamma_M = \Gamma_{\pyinline{builtins}}
 \runion \set{\text{\pyinline{__name__}} \mapsto \statusDefAssigned}$, where $\Gamma_{\pyinline{builtins}}$
 binds at status $\statusDefAssigned$ the names of the predefined module \pyinline{builtins} (\figref{predefined}).
@@ -289,8 +288,7 @@ binds at status $\statusDefAssigned$ the names of the predefined module \pyinlin
 \end{figure}
 
 The metafunction $\imports$ (\figref{modules}) extracts the set of modules a given module depends on,
-by collecting the module names mentioned in $\pyinline{import}$ and $\pyinline{from M import \ldots}$
-statements anywhere in the module body. It extends to blocks the same way $\assignsS$ does:
+by collecting the module names mentioned in \pyinline{import} statements anywhere in the module body. It extends to blocks the same way $\assignsS$ does:
 $\imports(s \cons b) = \imports(s) \cup \imports(b)$, and likewise to module bodies $m$ via
 $\imports(t \cons m) = \imports(t) \cup \imports(m)$. The metafunction $\parents$ collects the proper
 prefixes of a fully-qualified name.
@@ -650,6 +648,7 @@ functional programming:
 \item \pyinline{class} definitions (dataclasses may be added; see \S2 to-do list)
 \item \pyinline{with} statements
 \item List patterns matching tuple values, or tuple patterns matching list values. In \PurePy a list pattern matches only a list, and a tuple pattern matches only a tuple. Python permits either pattern against either kind of sequence.
+\item Wildcard imports (\pyinline{from M import *}); PEP 8 recommends avoiding these\footnote{\url{https://peps.python.org/pep-0008/}}.
 \end{itemize}
 
 \section{Operational semantics}


### PR DESCRIPTION
## Summary
- Adds wildcard imports (\`from M import *\`) to the list of unsupported Python features (§2.5), citing [PEP 8](https://peps.python.org/pep-0008/) which advises against them.
- Tightens §2.2 prose: refers to "import statements" generically rather than enumerating \`import\` and \`from import\` forms.

We initially started implementing wildcard imports in this branch, but discovered that the Python semantics (re-exporting any top-level imports a module performs) is genuinely surprising and an established anti-pattern. The defensible use case (re-exporting from sub-modules into a package's \`__init__.py\`) is narrow enough that we can do without.

\`__all__\` support is filed as #105 (deferred).

## Test plan
- [ ] LaTeX rebuilds cleanly.
- [ ] No grammar/well-formedness/eval changes; no impact on tests or impl.