### PR TITLE
Add pyodide test runner

### DIFF
--- a/.github/workflows/litmus-tests.yml
+++ b/.github/workflows/litmus-tests.yml
@@ -11,11 +11,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - '3.12'
-          - 'pypy3.10'
-          - 'graalpy-24.0'
-    name: test (${{ matrix.python-version }})
+        include:
+          - runtime: CPython
+            cli: python
+            version: '3.12'
+
+          - runtime: PyPy
+            cli: python --no-mypy
+            version: 'pypy3.10'
+
+          - runtime: GraalPy
+            cli: python --no-mypy
+            version: 'graalpy-24.0'
+
+          - runtime: Pyodide
+            cli: $PYODIDE_PYTHON --no-mypy
+            version: '3.12'
+
+    name: test (${{ matrix.runtime }})
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,16 +36,25 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.version }}
 
       - name: Install mypy
-        if: matrix.python-version == '3.12'
+        if: matrix.runtime == 'CPython'
         run: pip install mypy
 
+      - name: Install uv
+        if: matrix.runtime == 'Pyodide'
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Pyodide
+        if: matrix.runtime == 'Pyodide'
+        run: |
+          uv python install cpython-3.14.2-emscripten-wasm32-musl
+          PYODIDE_PYTHON=$(uv python find cpython-3.14.2-emscripten-wasm32-musl)
+          echo "PYODIDE_PYTHON=$PYODIDE_PYTHON" >> "$GITHUB_ENV"
+          
       - name: Run all tests
         run: |
-          if [ "${{ matrix.python-version }}" = "3.12" ]; then
-            test/run-all.sh python
-          else
-            test/run-all.sh python --no-mypy
-          fi
+          test/run-all.sh ${{ matrix.cli }}
+          
+


### PR DESCRIPTION
Fixes #121 

This PR adds `pyodide` as a runtime to the tests run by the GitHub action.

This is a bit tricky, since the tests are currently run by executing the `test/run_all.py` script, which uses `subprocess`, which is currently not available in `pyodide`. We therefore need to run that script with another python interpreter, which will internally call `pyodide` on the different test files. 

I also tried out different ways of how to install `pyodide` within the test runner:

- Installing `node` + custom JavaScript runner script
  - This adds an additional file that we need to keep up with
  - We would basically have to reimplement `run_all.py` in JavaScript
- Downloading the release artifact from `pyodide/pyodide` and using the `pyodide/python` CLI
  - This takes forever, since the artifact is about 500MB
- Using UV to install `pyodide` and then forwarding the interpreter in a custom environment variable
  - Very fast
  - Only needs changes in the GitHub action .yaml file, no changes required to the test script

I went for option 3 for now, since it is the fastest, and requires the least amount of change.   