### PR TITLE
More purity burble

### DIFF
--- a/PurePy-spec.tex
+++ b/PurePy-spec.tex
@@ -93,8 +93,8 @@
 \begin{abstract}
 \PurePy is a pure, side-effect-free subset of Python: a functional language whose programs are referentially
 transparent, reproducible, and easy to reason about, yet remain ordinary Python. Every well-formed \PurePy
-program is valid Python and runs with the same behaviour, so one source serves both a standard Python
-interpreter and any conforming implementation. This paper specifies \PurePy as a versioned standard, with a
+program is valid Python and runs with the same behaviour, so the same source runs under a standard Python
+interpreter and under any conforming implementation. This paper specifies \PurePy as a versioned standard, with a
 formal grammar, well-formedness rules based on a definite-assignment analysis, and an operational semantics
 that preserves the meaning of well-formed programs in Python. A reference checker decides membership of the
 subset, and a conformance test suite is exercised on CPython, PyPy, GraalPy, and Pyodide. Aimed first at researchers in programming languages and pedagogy, \PurePy

--- a/PurePy-spec.tex
+++ b/PurePy-spec.tex
@@ -42,7 +42,7 @@
 
 \begin{document}
 
-\newcommand{\basetitle}{A Pure Functional Subset of Python for Scientific Computing}
+\newcommand{\basetitle}{A Functional Subset of Python for Scientific Computing}
 \ifdefined\anonmode
   \title{\basetitle}
 \else

--- a/tex/conclusion.tex
+++ b/tex/conclusion.tex
@@ -7,3 +7,15 @@ Scientific computing in Python rests on libraries such as NumPy and Pandas, whos
 mutation and indexing. \PurePy therefore needs compatible counterparts: libraries, or subsets of existing
 ones, whose operations are pure. Polars,\footnote{\url{https://docs.pola.rs/}} whose operations return new frames rather than
 updating in place, suggests the shape such interfaces can take.
+
+\subsection{Typed effects}
+
+A future version of \PurePy may add a typed effect discipline, in the style of monadic effects or effect
+handlers. Such disciplines commonly coexist with native effects: Haskell tracks input and output in its
+\pyinline{IO} monad yet ships an untracked \pyinline{trace} for pure
+code,\footnote{\url{https://hackage.haskell.org/package/base/docs/Debug-Trace.html}} Lean likewise has
+\pyinline{dbg_trace}, and the monadic effect libraries of Scala operate alongside the language's native
+effects. We do not expect \PurePy's existing effects, printing included, to be an obstacle: printing can
+be reinterpreted as a typed output effect (a writer, in monadic terms), or kept native as it is now, with
+essentially equivalent semantics, because printed output never influences a program's result
+(\secref{purity}).

--- a/tex/conclusion.tex
+++ b/tex/conclusion.tex
@@ -10,12 +10,15 @@ updating in place, suggests the shape such interfaces can take.
 
 \subsection{Typed effects}
 
-A future version of \PurePy may add a typed effect discipline, in the style of monadic effects or effect
-handlers. Such disciplines commonly coexist with native effects: Haskell tracks input and output in its
-\pyinline{IO} monad yet ships an untracked \pyinline{trace} for pure
-code,\footnote{\url{https://hackage.haskell.org/package/base/docs/Debug-Trace.html}} Lean likewise has
-\pyinline{dbg_trace}, and the monadic effect libraries of Scala operate alongside the language's native
-effects. We do not expect \PurePy's existing effects, printing included, to be an obstacle: printing can
-be reinterpreted as a typed output effect (a writer, in monadic terms), or kept native as it is now, with
-essentially equivalent semantics, because printed output never influences a program's result
-(\secref{purity}).
+A future version of \PurePy may add a typed effect discipline. In a mypy-compatible type system the
+question is notational, because effect information must fit within annotations that Python and mypy
+already accept. A return type such as \pyinline{IO[int]} tracks effects as an ordinary generic type, in
+the Haskell style, though chaining is awkward in a language of statements without dedicated syntax.
+\pyinline{Annotated[int, Console]} (PEP 593) attaches effect metadata that mypy ignores and the \PurePy
+checker can read. Lightest is a decorator: with effects the default, \pyinline{@pure} marks functions in
+which printing and other effects are rejected, and unannotated code keeps its current meaning. Under any
+of these, existing support for printing is not an obstacle, since printing can be reinterpreted as a typed
+output effect or kept native with essentially equivalent semantics, printed output never influencing a
+result (\secref{purity}). Typed disciplines coexisting with native effects have precedent, from Haskell's
+untracked \pyinline{trace} in pure code\footnote{\url{https://hackage.haskell.org/package/base/docs/Debug-Trace.html}}
+to Scala's monadic effect libraries alongside the language's native effects.

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -23,10 +23,12 @@ reports on a computation without influencing its result.
 
 A more strict, but less useful, design would drop printing altogether. Without printing there is little
 reason to specify evaluation order, including the order in which modules load, and errors could be left to
-occur at unspecified points. We specify the order instead, for two reasons. A program that divides by zero
-should do so at the same point of execution on every run and under every implementation. And implementers
-will sooner or later add printing or something like it; a specification that ignores the possibility gives
-them no guidance when they do.
+occur at unspecified points. Leaving effects out might seem to spare implementers as well as us, but the
+saving would be ours alone, because basic effects are essential to a practical language, and sequential
+execution comes with them; implementations must provide both whether or not the specification describes
+them. So we describe them. A program that divides by zero should abort at the same point of execution on
+every run and under every implementation, and an implementer who adds printing or something like it should
+find the order of events already fixed.
 
 \subsection{Mutable state}
 \label{sec:no-mutable-state}

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -3,15 +3,14 @@
 
 \PurePy is a subset of Python chosen so that its programs are well-behaved and broadly \emph{pure}, yet run
 unchanged under a standard Python interpreter and compute the same result. \secref{purity} makes the purity
-claim precise; the rest of the section sets out the excluded features, grouped by the discipline each one
-protects, and \figref{prevented-errors} summarises the Python runtime errors that well-formedness rules
-out.
+claim precise and sets out the excluded features, grouped by the discipline each one protects;
+\figref{prevented-errors} summarises the Python runtime errors that well-formedness rules out.
 
 \subsection{Purity}
 \label{sec:purity}
 
-\PurePy's purity is practical rather than mathematical. In a \PurePy program a name means one thing
-wherever it is read: a variable, once definitely assigned, denotes a fixed value; a function is fixed by
+The name \PurePy makes a claim that printing and runtime failure might seem to contradict. The claim is
+purity in the senses that matter. In a \PurePy program a name means one thing wherever it is read: a variable, once definitely assigned, denotes a fixed value; a function is fixed by
 its definition; and a module's members are fixed once the module has loaded. Neither mutation nor
 evaluation order can change what a name denotes. Python permits much that breaks this discipline, so
 \PurePy tightens or excludes the idioms responsible.
@@ -30,7 +29,7 @@ them. So we describe them. A program that divides by zero should abort at the sa
 every run and under every implementation, and an implementer who adds printing or something like it should
 find the order of events already fixed.
 
-\subsection{Mutable state}
+\subsubsection{Mutable state}
 \label{sec:no-mutable-state}
 
 A variable in \PurePy denotes a fixed value once definitely assigned, so features that mutate or rebind state
@@ -55,7 +54,7 @@ result \pyinline{11}. \PurePy rejects the program, keeping closures over values 
 with Java's requirement that captured locals be effectively final~\cite[\S15.27.2]{gosling2025}. The rules that
 enforce this are given in \secref{captured-vars}.
 
-\subsection{Control flow and effects}
+\subsubsection{Control flow and effects}
 \label{sec:no-effects}
 
 \PurePy excludes loops with \pyinline{break} and \pyinline{continue}, exceptions
@@ -67,7 +66,7 @@ conjunction with mutable state, which \PurePy already excludes, and iteration is
 and recursion rather than by loops. A future release may add structured effects; for now the core stays
 effect-free.
 
-\subsection{Implicit coercions}
+\subsubsection{Implicit coercions}
 \label{sec:no-coercions}
 
 Python accepts several implicit coercions and lax matches that are convenient but a recognised source of error,
@@ -79,7 +78,7 @@ pattern match a list, whereas in \PurePy a list pattern matches only a list and 
 The third is in constructor patterns: Python lets a positional class pattern supply fewer sub-patterns than the
 class's field arity, matching only those given, whereas \PurePy requires the exact arity.
 
-\subsection{Load-dependent meaning}
+\subsubsection{Load-dependent meaning}
 \label{sec:no-load-dependent}
 
 A name's meaning in \PurePy must not depend on the order in which modules load or on runtime state, so several
@@ -156,7 +155,7 @@ module member the module body never assigns, such as \pyinline{lib.x} where \pyi
 \pyinline{x} only on a branch that is not taken. In Python both cases raise \pyinline{AttributeError}; \PurePy
 rejects them statically.
 
-\subsection{Modules and classes are not first-class}
+\subsubsection{Modules and classes are not first-class}
 \label{sec:no-first-class}
 
 For now, modules and classes are not values in \PurePy. In Python a module is a value and a class declaration
@@ -168,7 +167,7 @@ class is identified by its qualified name, a dataclass declaration may not re-de
 denotes a class in the module; Python permits the re-declaration, leaving the earlier class reachable only
 through its existing instances.
 
-\subsection{Other restrictions}
+\subsubsection{Other restrictions}
 \label{sec:other-restrictions}
 
 A few remaining restrictions do not fit the groups above. Only dataclasses are supported, so \pyinline{class}

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -9,7 +9,7 @@ claim precise and sets out the excluded features, grouped by the discipline each
 \subsection{Purity}
 \label{sec:purity}
 
-The name \PurePy makes a claim that printing and runtime failure might seem to contradict. The claim is
+The name \PurePy makes a claim that some features of the language might seem to contradict. The claim is
 not that every \PurePy program terminates with exit status zero; a language that guaranteed only that
 would be singularly useless. The claim is purity in the senses that matter. In a \PurePy program a name means one thing wherever it is read: a variable, once definitely assigned, denotes a fixed value; a function is fixed by
 its definition; and a module's members are fixed once the module has loaded. Neither mutation nor

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -61,7 +61,7 @@ enforce this are given in \secref{captured-vars}.
 
 \PurePy excludes loops with \pyinline{break} and \pyinline{continue}, exceptions
 (\pyinline{try}/\allowbreak\pyinline{except}/\allowbreak\pyinline{raise}), context managers (\pyinline{with}), generators
-(\pyinline{yield}/\allowbreak\pyinline{yield from}), and coroutines (\pyinline{async}/\pyinline{await}). Functional
+(\pyinline{yield}/\allowbreak\pyinline{yield from}), and coroutines (\pyinline{async}/\allowbreak\pyinline{await}). Functional
 programming has rich accounts of effects, from monads to algebraic effect handlers, so these features are not
 inherently at odds with a functional language. In idiomatic Python, though, they are used mainly in
 conjunction with mutable state, which \PurePy already excludes, and iteration is expressed by comprehensions

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -10,23 +10,22 @@ claim precise and sets out the excluded features, grouped by the discipline each
 \subsection{Purity}
 \label{sec:purity}
 
-The name \PurePy makes a claim that some features of the language might seem to contradict. The claim is
-not that every \PurePy program terminates with exit status zero; a language that guaranteed only that
-would be singularly useless. The claim is purity in the senses that matter. In a \PurePy program a name means one thing wherever it is read: a variable, once definitely assigned, denotes a fixed value; a function is fixed by
-its definition; and a module's members are fixed once the module has loaded. Neither mutation nor
-evaluation order can change what a name denotes. Python permits much that breaks this discipline, so
-\PurePy tightens or excludes the idioms responsible.
+\PurePy is not semantically ``pure'' in the sense of providing a guarantee that every program terminates with
+a unique value. No practical programming language is pure in this sense. Real programs may fail to terminate,
+or abort at runtime with errors such as division-by-zero or index-out-of-bounds, even in languages regarded as
+(mostly) pure, like Haskell. What we do claim is that \PurePy is pure in the senses that matter. Every name
+has a unique lexical scope; a variable, once definitely assigned, denotes a fixed value; a module's members
+are fixed once the module has loaded. Neither mutation nor evaluation order can change the meaning of a name.
+Python permits much that breaks this discipline, so \PurePy tightens or excludes the idioms responsible.
 
-No practical language is mathematically pure. \PurePy programs may fail to terminate, and they abort at
-runtime on errors such as division by zero or an index out of bounds, as programs do even in languages
-regarded as pure. \PurePy also supports printing, a genuine effect, but a benign one, since printing
-reports on a computation without influencing its result.
-
-A more strict, but less useful, design would drop printing altogether. With failure the only effect left,
-the point at which a program fails cannot be observed, and evaluation order, including the order in which
-modules load, could go unspecified. But this works only while failures are indistinguishable. If division
-by zero reports differently from an index out of bounds, then a program with two possible failures shows
-which was reached first, and evaluation order is observable after all.
+Real-world languages, including the ``pure'' ones, also support logging output to a terminal. \PurePy does
+too. This too is a computational effect, but one that is not only indispensable but benign, since printing can
+only report on a computation and cannot influence its result. A more strict, but less useful, design would
+drop printing altogether. With failure the only effect left, the point at which a program fails cannot be
+observed, and evaluation order, including the order in which modules load, could go unspecified. But this
+works only while failures are indistinguishable. If division by zero reports differently from an index out of
+bounds, then a program with two possible failures shows which was reached first, and evaluation order is
+observable after all.
 
 Leaving effects out might seem to spare implementers as well as us, but the saving would be ours alone.
 Basic effects are essential to a practical language, and sequential execution comes with them, so

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -10,20 +10,23 @@ out.
 \subsection{Purity}
 \label{sec:purity}
 
-\PurePy does not claim purity in a mathematical sense, because no practical language has it: even
-ostensibly pure languages admit non-termination, and their programs abort on runtime errors such as
-division by zero or an index out of bounds. \PurePy also supports printing, which is more plainly an
-effect, though a benign one, because printing observes a computation without influencing its result. The
-purity \PurePy claims is purity in the senses that matter for reasoning about programs: a name's meaning
-does not depend on evaluation order or on mutation; a variable, once definitely assigned, denotes a fixed
-value; a function is fixed by its definition; and a module's members are fixed once it has loaded. Python
-permits much that breaks this discipline, so \PurePy tightens or excludes the idioms responsible.
+\PurePy's purity is practical rather than mathematical. In a \PurePy program a name means one thing
+wherever it is read: a variable, once definitely assigned, denotes a fixed value; a function is fixed by
+its definition; and a module's members are fixed once the module has loaded. Neither mutation nor
+evaluation order can change what a name denotes. Python permits much that breaks this discipline, so
+\PurePy tightens or excludes the idioms responsible.
 
-A more strict, but less useful, design would drop printing and decline to specify evaluation order, for
-example the order in which modules load. We reject this alternative for two reasons. First, errors should occur at determinate points; a program
-that divides by zero should do so at the same point of execution on every run and under every
-implementation. Second, implementers will sooner or later add observations such as printing, and a
-specification that ignores this possibility no longer suggests an implementation strategy once they do.
+Mathematical purity is out of reach for any practical language, and we do not claim it. \PurePy programs
+may fail to terminate, and they abort at runtime on errors such as division by zero or an index out of
+bounds, as programs do in ostensibly pure languages too. \PurePy also supports printing, a genuine
+effect, but a benign one, since printed output observes a computation without influencing its result.
+
+A more strict, but less useful, design would claim more by supporting less. Without printing there is
+little reason to specify evaluation order, including the order in which modules load, and errors could be
+left to occur at unspecified points. We specify the order instead, for two reasons. A program that divides
+by zero should do so at the same point of execution on every run and under every implementation. And
+implementers will sooner or later add observations such as printing, so a specification that ignores this
+possibility stops suggesting an implementation strategy at exactly the point one is needed.
 
 \subsection{Mutable state}
 \label{sec:no-mutable-state}

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -60,8 +60,8 @@ enforce this are given in \secref{captured-vars}.
 \label{sec:no-effects}
 
 \PurePy excludes loops with \pyinline{break} and \pyinline{continue}, exceptions
-(\pyinline{try}/\pyinline{except}/\pyinline{raise}), context managers (\pyinline{with}), generators
-(\pyinline{yield}/\pyinline{yield from}), and coroutines (\pyinline{async}/\pyinline{await}). Functional
+(\pyinline{try}/\allowbreak\pyinline{except}/\allowbreak\pyinline{raise}), context managers (\pyinline{with}), generators
+(\pyinline{yield}/\allowbreak\pyinline{yield from}), and coroutines (\pyinline{async}/\pyinline{await}). Functional
 programming has rich accounts of effects, from monads to algebraic effect handlers, so these features are not
 inherently at odds with a functional language. In idiomatic Python, though, they are used mainly in
 conjunction with mutable state, which \PurePy already excludes, and iteration is expressed by comprehensions

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -18,21 +18,33 @@ has a unique lexical scope; a variable, once definitely assigned, denotes a fixe
 are fixed once the module has loaded. Neither mutation nor evaluation order can change the meaning of a name.
 Python permits much that breaks this discipline, so \PurePy tightens or excludes the idioms responsible.
 
+\Added{Failure alone is enough to make evaluation order observable. Division by zero reports differently from
+an index out of bounds, so a program with two possible failures reveals which was reached first. Evaluation
+order could be left unspecified only if failures were indistinguishable, which is not a practical assumption,
+since which error a program reports is part of what its users see. \PurePy therefore specifies evaluation
+order, including the order in which modules load, so that a program which divides by zero aborts at the same
+point of execution on every run and under every implementation.}
+
 Real-world languages, including the ``pure'' ones, also support logging output to a terminal. \PurePy does
 too. This too is a computational effect, but one that is not only indispensable but benign, since printing can
-only report on a computation and cannot influence its result. A more strict, but less useful, design would
+only report on a computation and cannot influence its result. \Replaced{With evaluation order already
+settled, printing is a minor extension. A case can be made for leaving it out of the core, and little would
+be lost by doing so, since the substantial part of the specification for implementers is the evaluation
+order, which stands either way. Idealising further, to a language with no effects at all or with
+indistinguishable failures, would leave that part out, and an implementer who then added printing would have
+to fix the order of events without guidance.}{A more strict, but less useful, design would
 drop printing altogether. With failure the only effect left, the point at which a program fails cannot be
 observed, and evaluation order, including the order in which modules load, could go unspecified. But this
 works only while failures are indistinguishable. If division by zero reports differently from an index out of
 bounds, then a program with two possible failures shows which was reached first, and evaluation order is
-observable after all.
+observable after all.}
 
-Leaving effects out might seem to spare implementers as well as us, but the saving would be ours alone.
+\Deleted{Leaving effects out might seem to spare implementers as well as us, but the saving would be ours alone.
 Basic effects are essential to a practical language, and sequential execution comes with them, so
 implementations must provide both whether or not the specification describes them. So we describe them. A
 program that divides by zero aborts at the same point of execution on every run and under every
 implementation, and an implementer who adds printing or something like it finds the order of events
-already fixed.
+already fixed.}
 
 \subsubsection{Mutable state}
 \label{sec:no-mutable-state}

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -10,7 +10,8 @@ claim precise and sets out the excluded features, grouped by the discipline each
 \label{sec:purity}
 
 The name \PurePy makes a claim that printing and runtime failure might seem to contradict. The claim is
-purity in the senses that matter. In a \PurePy program a name means one thing wherever it is read: a variable, once definitely assigned, denotes a fixed value; a function is fixed by
+not that every \PurePy program terminates with exit status zero; a language that guaranteed only that
+would be singularly useless. The claim is purity in the senses that matter. In a \PurePy program a name means one thing wherever it is read: a variable, once definitely assigned, denotes a fixed value; a function is fixed by
 its definition; and a module's members are fixed once the module has loaded. Neither mutation nor
 evaluation order can change what a name denotes. Python permits much that breaks this discipline, so
 \PurePy tightens or excludes the idioms responsible.

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -236,7 +236,7 @@ Primitive operations & \issue{132} \\
 \end{tabular}
 \end{minipage}
 \end{center}
-\caption{Planned additions and features under consideration \todo{working figure, for the authors; remove before submission}}
+\caption{\todo{Planned additions and features under consideration}}
 \label{fig:roadmap}
 \end{figure}
 

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -22,14 +22,18 @@ runtime on errors such as division by zero or an index out of bounds, as program
 regarded as pure. \PurePy also supports printing, a genuine effect, but a benign one, since printing
 reports on a computation without influencing its result.
 
-A more strict, but less useful, design would drop printing altogether. Without printing there is little
-reason to specify evaluation order, including the order in which modules load, and errors could be left to
-occur at unspecified points. Leaving effects out might seem to spare implementers as well as us, but the
-saving would be ours alone, because basic effects are essential to a practical language, and sequential
-execution comes with them; implementations must provide both whether or not the specification describes
-them. So we describe them. A program that divides by zero should abort at the same point of execution on
-every run and under every implementation, and an implementer who adds printing or something like it should
-find the order of events already fixed.
+A more strict, but less useful, design would drop printing altogether. With failure the only effect left,
+the point at which a program fails cannot be observed, and evaluation order, including the order in which
+modules load, could go unspecified. But this works only while failures are indistinguishable. If division
+by zero reports differently from an index out of bounds, then a program with two possible failures shows
+which was reached first, and evaluation order is observable after all.
+
+Leaving effects out might seem to spare implementers as well as us, but the saving would be ours alone.
+Basic effects are essential to a practical language, and sequential execution comes with them, so
+implementations must provide both whether or not the specification describes them. So we describe them. A
+program that divides by zero aborts at the same point of execution on every run and under every
+implementation, and an implementer who adds printing or something like it finds the order of events
+already fixed.
 
 \subsubsection{Mutable state}
 \label{sec:no-mutable-state}

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -18,12 +18,16 @@ has a unique lexical scope; a variable, once definitely assigned, denotes a fixe
 are fixed once the module has loaded. Neither mutation nor evaluation order can change the meaning of a name.
 Python permits much that breaks this discipline, so \PurePy tightens or excludes the idioms responsible.
 
-\Added{Failure alone is enough to make evaluation order observable. Division by zero reports differently from
-an index out of bounds, so a program with two possible failures reveals which was reached first. Evaluation
-order could be left unspecified only if failures were indistinguishable, which is not a practical assumption,
-since which error a program reports is part of what its users see. \PurePy therefore specifies evaluation
-order, including the order in which modules load, so that a program which divides by zero aborts at the same
-point of execution on every run and under every implementation.}
+\Added{A specification need not say in what order a program does its work, provided no program can tell.
+Where the result of a program is all that can be observed, the order in which subexpressions are evaluated,
+or in which modules load, cannot affect that result, and each implementation is free to choose its own.
+Failure removes that freedom. Division by zero reports differently from an index out of bounds, so a program
+with two possible failures reveals which was reached first, and implementations which chose different orders
+would disagree about what such a program does. The freedom could be kept only if failures were
+indistinguishable, which is not a practical assumption, since which error a program reports is part of what
+its users see. \PurePy therefore fixes the order in which expressions are evaluated and modules are loaded,
+so that a program which divides by zero aborts at the same point of execution on every run and under every
+implementation.}
 
 Real-world languages, including the ``pure'' ones, also support logging output to a terminal. \PurePy does
 too. This too is a computational effect, but one that is not only indispensable but benign, since printing can

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -236,7 +236,7 @@ Primitive operations & \issue{132} \\
 \end{tabular}
 \end{minipage}
 \end{center}
-\caption{Planned additions and features under consideration}
+\caption{Planned additions and features under consideration \todo{working figure, for the authors; remove before submission}}
 \label{fig:roadmap}
 \end{figure}
 

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -16,17 +16,17 @@ its definition; and a module's members are fixed once the module has loaded. Nei
 evaluation order can change what a name denotes. Python permits much that breaks this discipline, so
 \PurePy tightens or excludes the idioms responsible.
 
-Mathematical purity is out of reach for any practical language, and we do not claim it. \PurePy programs
-may fail to terminate, and they abort at runtime on errors such as division by zero or an index out of
-bounds, as programs do in ostensibly pure languages too. \PurePy also supports printing, a genuine
-effect, but a benign one, since printed output observes a computation without influencing its result.
+No practical language is mathematically pure. \PurePy programs may fail to terminate, and they abort at
+runtime on errors such as division by zero or an index out of bounds, as programs do even in languages
+regarded as pure. \PurePy also supports printing, a genuine effect, but a benign one, since printing
+reports on a computation without influencing its result.
 
-A more strict, but less useful, design would claim more by supporting less. Without printing there is
-little reason to specify evaluation order, including the order in which modules load, and errors could be
-left to occur at unspecified points. We specify the order instead, for two reasons. A program that divides
-by zero should do so at the same point of execution on every run and under every implementation. And
-implementers will sooner or later add observations such as printing, so a specification that ignores this
-possibility stops suggesting an implementation strategy at exactly the point one is needed.
+A more strict, but less useful, design would drop printing altogether. Without printing there is little
+reason to specify evaluation order, including the order in which modules load, and errors could be left to
+occur at unspecified points. We specify the order instead, for two reasons. A program that divides by zero
+should do so at the same point of execution on every run and under every implementation. And implementers
+will sooner or later add printing or something like it; a specification that ignores the possibility gives
+them no guidance when they do.
 
 \subsection{Mutable state}
 \label{sec:no-mutable-state}

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -13,31 +13,32 @@ claim precise and sets out the excluded features, grouped by the discipline each
 \PurePy is not semantically ``pure'' in the sense of providing a guarantee that every program terminates with
 a unique value. No practical programming language is pure in this sense. Real programs may fail to terminate,
 or abort with errors such as division-by-zero or index-out-of-bounds, even in languages regarded as (mostly)
-pure, like Haskell. However, we do claim that \PurePy is pure in the senses that matter. Every name has a
-unique lexical scope; a variable, once definitely assigned, denotes a fixed value; a module's members are
-fixed once the module has loaded. There is no mutation, nor can evaluation order change the meaning of a name.
-Python operates largely outside this discipline, and the goal of \PurePy is to characterise a suitably large
-subset of Python that stays within it.
+pure, like Haskell.
 
-A specification need not say in what order a program does its work, as long as no program can tell. If
-the result of a program is all that can be observed, the order in which subexpressions are evaluated (or in
-which modules load) cannot affect that result; and implementations are free to choose. Runtime errors, as long
-as they can be distinguished, remove that freedom: if division-by-zero reports differently from index-out of
-bounds, so a program with two possible failures reveals which was reached first, and implementations which
-chose different orders would disagree about what such a program does. The freedom could be kept only if
-failures were indistinguishable, which is not a practical assumption, since which error a program reports is
-part of what its users see. \PurePy therefore fixes the order in which expressions are evaluated and modules
-are loaded, so that a program which divides by zero aborts at the same point of execution on every run and
-under every implementation.
+We do, however, claim that \PurePy is pure in the senses that matter. Every name has a unique lexical scope; a
+variable, once definitely assigned, denotes a fixed value; a module's members are fixed once the module has
+loaded. There is no mutation, nor can evaluation order change the meaning of a name. Python operates largely
+outside this discipline, and the goal of \PurePy is to characterise a suitably large subset of Python that
+stays within it.
 
-Real-world languages, including the ``pure'' ones, also support logging output to a terminal. \PurePy does
-too. This too is a computational effect, but one that is not only indispensable but benign, since printing can
-only report on a computation and cannot influence its result. With evaluation order already
-settled, printing is a minor extension. A case can be made for leaving it out of the core, and little would
-be lost by doing so, since the substantial part of the specification for implementers is the evaluation
-order, which stands either way. Idealising further, to a language with no effects at all or with
-indistinguishable failures, would leave that part out, and an implementer who then added printing would have
-to fix the order of events without guidance.
+A non-trivial component of the PurePy specification concerns module loading, in the form of well-formedness
+rules which rule out programs which depend on Python's load-order-sensitive behaviours
+(\secref{no-load-dependent}). One might wonder why a language which is mutation-free even needs to concern
+itself with loading order. If the result of a program is all that can be observed, the order in which
+subexpressions are evaluated cannot affect that result, and so cannot meaningfully be part of the
+specification. However runtime errors, at least if they can be distinguished, remove that freedom: if
+division-by-zero reports differently from index-out-of-bounds, a program with two possible failures reveals
+which was reached first, and implementations which choose different orders might disagree about what such a
+program does. \PurePy aims to serve as a template for practical implementation, not as an idealised calculus,
+and practical implementations need to be able to report on different kinds of error, since those reports are
+important to users. The sequential semantics of module loading therefore remains an important part of the
+specification so that programs which fail do so deterministically under every implementation.
+
+Real-world languages, including the ``pure'' ones, also support logging to a terminal. Haskell has
+\pyinline{trace}; \PurePy has \pyinline{print}, following Python. This too is a computational effect, but one
+that is not only indispensable but benign; printing can only report on a computation and cannot influence its
+result. Moreover with loading order already part of the specification, printing is a low-cost, high-utility
+feature that leaves the core purity benefits of \PurePy untouched.
 
 \subsubsection{Mutable state}
 \label{sec:no-mutable-state}
@@ -156,7 +157,6 @@ Loading \pyinline{pkg.sub}, wherever in the program it happens, sets it as an at
 mentions \pyinline{pkg.sub}. The name has no load-order-independent meaning, so \PurePy prohibits the clash
 outright.
 
-\label{sec:uninitialised-members}
 For the same reason, a module may not refer to a submodule it does not itself import. A submodule is not an
 attribute of its package until it is loaded, so \pyinline{import a} followed by \pyinline{a.b.f()} is rejected
 unless the module also imports \pyinline{a.b}; Python permits the reference whenever some earlier import,

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -4,7 +4,8 @@
 \PurePy is a subset of Python chosen so that its programs are well-behaved and broadly \emph{pure}, yet run
 unchanged under a standard Python interpreter and compute the same result. \secref{purity} makes the purity
 claim precise and sets out the excluded features, grouped by the discipline each one protects;
-\figref{prevented-errors} summarises the Python runtime errors that well-formedness rules out.
+\figref{prevented-errors} summarises the Python runtime errors that well-formedness rules out, and
+\figref{roadmap} lists planned additions and features under consideration.
 
 \subsection{Purity}
 \label{sec:purity}
@@ -197,7 +198,8 @@ scope of well-formedness.
 \label{fig:prevented-errors}
 \end{figure}
 
-{\small
+\begin{figure}
+\small
 \begin{center}
 \begin{minipage}[t]{0.4\textwidth}
 \vspace{0pt}
@@ -233,5 +235,8 @@ Postponed annotation evaluation & \issue{128} \\
 Primitive operations & \issue{132} \\
 \end{tabular}
 \end{minipage}
-\end{center}}
+\end{center}
+\caption{Planned additions and features under consideration}
+\label{fig:roadmap}
+\end{figure}
 

--- a/tex/overview.tex
+++ b/tex/overview.tex
@@ -12,43 +12,32 @@ claim precise and sets out the excluded features, grouped by the discipline each
 
 \PurePy is not semantically ``pure'' in the sense of providing a guarantee that every program terminates with
 a unique value. No practical programming language is pure in this sense. Real programs may fail to terminate,
-or abort at runtime with errors such as division-by-zero or index-out-of-bounds, even in languages regarded as
-(mostly) pure, like Haskell. What we do claim is that \PurePy is pure in the senses that matter. Every name
-has a unique lexical scope; a variable, once definitely assigned, denotes a fixed value; a module's members
-are fixed once the module has loaded. Neither mutation nor evaluation order can change the meaning of a name.
-Python permits much that breaks this discipline, so \PurePy tightens or excludes the idioms responsible.
+or abort with errors such as division-by-zero or index-out-of-bounds, even in languages regarded as (mostly)
+pure, like Haskell. However, we do claim that \PurePy is pure in the senses that matter. Every name has a
+unique lexical scope; a variable, once definitely assigned, denotes a fixed value; a module's members are
+fixed once the module has loaded. There is no mutation, nor can evaluation order change the meaning of a name.
+Python operates largely outside this discipline, and the goal of \PurePy is to characterise a suitably large
+subset of Python that stays within it.
 
-\Added{A specification need not say in what order a program does its work, provided no program can tell.
-Where the result of a program is all that can be observed, the order in which subexpressions are evaluated,
-or in which modules load, cannot affect that result, and each implementation is free to choose its own.
-Failure removes that freedom. Division by zero reports differently from an index out of bounds, so a program
-with two possible failures reveals which was reached first, and implementations which chose different orders
-would disagree about what such a program does. The freedom could be kept only if failures were
-indistinguishable, which is not a practical assumption, since which error a program reports is part of what
-its users see. \PurePy therefore fixes the order in which expressions are evaluated and modules are loaded,
-so that a program which divides by zero aborts at the same point of execution on every run and under every
-implementation.}
+A specification need not say in what order a program does its work, as long as no program can tell. If
+the result of a program is all that can be observed, the order in which subexpressions are evaluated (or in
+which modules load) cannot affect that result; and implementations are free to choose. Runtime errors, as long
+as they can be distinguished, remove that freedom: if division-by-zero reports differently from index-out of
+bounds, so a program with two possible failures reveals which was reached first, and implementations which
+chose different orders would disagree about what such a program does. The freedom could be kept only if
+failures were indistinguishable, which is not a practical assumption, since which error a program reports is
+part of what its users see. \PurePy therefore fixes the order in which expressions are evaluated and modules
+are loaded, so that a program which divides by zero aborts at the same point of execution on every run and
+under every implementation.
 
 Real-world languages, including the ``pure'' ones, also support logging output to a terminal. \PurePy does
 too. This too is a computational effect, but one that is not only indispensable but benign, since printing can
-only report on a computation and cannot influence its result. \Replaced{With evaluation order already
+only report on a computation and cannot influence its result. With evaluation order already
 settled, printing is a minor extension. A case can be made for leaving it out of the core, and little would
 be lost by doing so, since the substantial part of the specification for implementers is the evaluation
 order, which stands either way. Idealising further, to a language with no effects at all or with
 indistinguishable failures, would leave that part out, and an implementer who then added printing would have
-to fix the order of events without guidance.}{A more strict, but less useful, design would
-drop printing altogether. With failure the only effect left, the point at which a program fails cannot be
-observed, and evaluation order, including the order in which modules load, could go unspecified. But this
-works only while failures are indistinguishable. If division by zero reports differently from an index out of
-bounds, then a program with two possible failures shows which was reached first, and evaluation order is
-observable after all.}
-
-\Deleted{Leaving effects out might seem to spare implementers as well as us, but the saving would be ours alone.
-Basic effects are essential to a practical language, and sequential execution comes with them, so
-implementations must provide both whether or not the specification describes them. So we describe them. A
-program that divides by zero aborts at the same point of execution on every run and under every
-implementation, and an implementer who adds printing or something like it finds the order of events
-already fixed.}
+to fix the order of events without guidance.
 
 \subsubsection{Mutable state}
 \label{sec:no-mutable-state}

--- a/tex/syntax.tex
+++ b/tex/syntax.tex
@@ -235,13 +235,19 @@ R \override \Returns = \Returns \override R & = \Returns
 \]
 \end{lemma}
 
-\noindent A module attribute reference is well-formed only when it resolves to a definitely assigned member (rule \ruleName{attr-module}); see \secref{uninitialised-members}.
+\noindent A module attribute reference is well-formed only when it resolves to a definitely assigned member
+(rule \ruleName{attr-module}); see \secref{no-load-dependent}.
 
 \input{fig/well-formed}
 \input{fig/well-formed-expr}
 \input{fig/well-formed-module}
 
-The signature $\Gamma$ a module's load judgement produces (\figref{well-formed-module}) comprises the classes and variables a module defines, together with its intrinsic \pyinline{__name__} and a stub for each submodule, never the names it imports: following PEP 484\footnote{\url{https://peps.python.org/pep-0484/}}, an imported name is a private dependency, not re-exported as part of the interface. Submodule stubs and the module's own bindings are disjoint, because the module rules prohibit a module from binding a name that is also the name of a submodule (\secref{no-load-dependent}).
+The signature $\Gamma$ a module's load judgement produces (\figref{well-formed-module}) comprises the classes
+and variables a module defines, together with its intrinsic \pyinline{__name__} and a stub for each submodule,
+never the names it imports: following PEP 484\footnote{\url{https://peps.python.org/pep-0484/}}, an imported
+name is a private dependency, not re-exported as part of the interface. Submodule stubs and the module's own
+bindings are disjoint, because the module rules prohibit a module from binding a name that is also the name of
+a submodule (\secref{no-load-dependent}).
 
 \subsection{Examples}
 


### PR DESCRIPTION
A bit more of an argument for why PurePy is "pure", but why load-order still matters, and so modules aren't just "namespaces". And a soft argument for why `print` should probably be included too.